### PR TITLE
Make sure publisher DOM element is created if local participant mic or cam are on

### DIFF
--- a/src/Session.ts
+++ b/src/Session.ts
@@ -152,6 +152,10 @@ export class Session extends OTEventEmitter<{
       properties = undefined;
     }
 
+    if (callback) {
+      completionHandler = callback;
+    }
+
     if (!completionHandler) {
       completionHandler = () => {
         // intentionally empty function
@@ -234,7 +238,7 @@ export class Session extends OTEventEmitter<{
       this.connection = connection;
       this.ee.emit("streamCreated", streamEvent);
     });
-
+    completionHandler();
     return publisher;
   }
   connect(token: string, callback: (error?: OTError) => void): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -276,12 +276,22 @@ export function initPublisher(
     window.call.setLocalAudio(true);
   }
 
+  if (completionHandler !== undefined) {
+    runDelayedCallback(completionHandler);
+  }
   return publisher;
 }
 
 let OTlogLevel = 0;
 export function setLogLevel(logLevel: number): void {
   OTlogLevel = logLevel;
+}
+
+// I'm sorry.
+async function runDelayedCallback(callback: (error?: OTError) => void) {
+  setTimeout(() => {
+    callback();
+  }, 1000);
 }
 
 export function log(message: string): void {


### PR DESCRIPTION
Fix some discrepancies that make accelerator lib not work as expected. End result with Daily in accelerator sample app:

<img width="782" alt="image" src="https://user-images.githubusercontent.com/65890040/195642424-a6041ec6-2ebd-445f-a8c7-aff5ad3ce805.png">

Summary of changes (pasted from Slack)

## `"participant-updated"` and DOM elements

We currently subscribe the `“participant-updated”` event too late after the participant was actually updated. This can be fixed by checking if participant has video or audio on and appending the video element to the DOM without waiting for a `“participant-update”` in this case.

## Completion callbacks

We currently aren’t calling the callback provided for the completion handler consistently on completion, only on error. It seems like this needs to be called on completion as well (with an undefined error if there is no error). This should fix the accelerator lib hanging while waiting for the handler to be called.

## Callback timing/usage of return value in callback

The opetok client lib, when initializing a publisher, does not call the completion handler _immediately_ after creation but actually does it at some future point when some other internal events are emitted. This means the caller (the accelerator lib) in this case gets the publisher return value and _can then use that publisher_ in their completion handler callback, because the completion handler runs after the return.

This does not happen in our case - we do not have any additional events to wait for, so currently our completion handler runs _before_ the publisher return value is available, and therefore the publisher value is undefined when the callback tries to use it. As a very temporary workaround to test this theory I’m going to do something very bad and have the callback run async with a second or two delay >.> Please don’t kill me.