### PR TITLE
Readd optional chaining to participant video and audio check

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -264,8 +264,10 @@ export function initPublisher(
   });
 
   const localParticipant = window.call.participants().local;
+  /* eslint-disable @typescript-eslint/no-unnecessary-condition */
   const videoOn = localParticipant?.video;
   const audioOn = localParticipant?.audio;
+  /* eslint-enable */
   if (videoOn || audioOn) {
     updateLocalVideoDOM(localParticipant, dailyElementId, publisher);
   }


### PR DESCRIPTION
This PR readds the optional check when querying the local participant's video and audio when initializing the publisher. I believe that at this point the local participant can be falsy and we'd encounter an exception here without this check.