### PR TITLE
build: fix issue with default export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "daily-opentok-client",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "daily-opentok-client",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "BSD-2",
       "dependencies": {
         "@daily-co/daily-js": "^0.31.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "daily-opentok-client",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "license": "BSD-2",
   "description": "Daily Tokbox shim",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -310,14 +310,6 @@ export function registerScreenSharingExtension(
   return;
 }
 
-export default {
-  checkSystemRequirements,
-  upgradeSystemRequirements,
-  getDevices,
-  initSession,
-  initPublisher,
-};
-
 function updateLocalVideoDOM(
   participant: DailyParticipant,
   dailyElementId: string,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,6 @@
 import { dirname } from "path";
 import { fileURLToPath } from "url";
-import { defineConfig } from "vite";
+import { defineConfig, LibraryOptions } from "vite";
 import mkcert from "vite-plugin-mkcert";
 
 // https://vitejs.dev/config/
@@ -14,7 +14,8 @@ export default defineConfig(({ command, mode }) => {
 
   const fileName = isBuild ? "opentok" : "index";
 
-  const lib = {
+  const lib: LibraryOptions = {
+    formats: ["es", "umd"],
     entry,
     name: "OT",
     // the proper extensions will be added
@@ -25,15 +26,8 @@ export default defineConfig(({ command, mode }) => {
     plugins: [mkcert()],
     build: {
       minify: !isDev,
+      sourcemap: isDev,
       lib,
-      rollupOptions: {
-        output: {
-          format: "iife",
-          name: "OT",
-          exports: "named",
-          sourcemap: isDev,
-        },
-      },
     },
     server: { https: true },
   };


### PR DESCRIPTION
A few things were confusing VIte/Rollup:
- Some Vite options map to rollup ones, so they could be moved to `lib` instead.
- Mixing default/named exports was unnecessary and could cause situations where `default` was being appended to `window.OT` in some cases and `window.OT` not being defined in other cases.

After reading through the docs I made a simpler configuration that is working when I text the running the bundle in a script tag in [this demo ](https://codesandbox.io/s/opentok-demo-forked-79zzbk?file=/index.html) (screenshot below):

![image](https://user-images.githubusercontent.com/614910/196885012-2bb85ab0-8f57-4a4d-a2dd-fe018dd8fa08.png)
