### PR TITLE
build:enable sourcemaps in production, export iife

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   "exports": {
     ".": {
       "import": "./dist/opentok.js",
-      "require": "./dist/opentok.umd.cjs"
+      "require": "./dist/opentok.umd.cjs",
+      "default": "./dist/opentok.iife.js",
+      "node": "./dist/opentok.umd.cjs"
     }
   },
   "types": "./dist/src/index.d.ts",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig(({ command, mode }) => {
   const fileName = isBuild ? "opentok" : "index";
 
   const lib: LibraryOptions = {
-    formats: ["es", "umd"],
+    formats: ["es", "umd", "iife"],
     entry,
     name: "OT",
     // the proper extensions will be added
@@ -26,7 +26,7 @@ export default defineConfig(({ command, mode }) => {
     plugins: [mkcert()],
     build: {
       minify: !isDev,
-      sourcemap: isDev,
+      sourcemap: true,
       lib,
     },
     server: { https: true },


### PR DESCRIPTION
For some reason the umd build works fine when you access it from a script tag locally, but doesn't export a global `OT` object when accessed through the unpkg.com link. This PR creates a 3rd bundle called opentok.iife.js. This wraps the library in an [Immediately Invoked Function Expression](https://developer.mozilla.org/en-US/docs/Glossary/IIFE) which adds the `OT` library to the `window` in the browser.

Screenshot:
![image](https://user-images.githubusercontent.com/614910/197705064-494affbe-de28-4496-b777-4def1c5ab8a9.png)
