### PR TITLE
feat: implement getActiveAudioOutputDevice and use default export

### DIFF
--- a/src/Session.ts
+++ b/src/Session.ts
@@ -12,7 +12,7 @@ import { OTEventEmitter } from "./OTEventEmitter";
 import { Publisher } from "./Publisher";
 import { Subscriber } from "./Subscriber";
 import { getParticipantTracks, getVideoTagID, notImplemented } from "./utils";
-import { initPublisher } from "./index";
+import OT from "./index";
 
 interface SessionCollection {
   length: () => number;
@@ -167,7 +167,7 @@ export class Session extends OTEventEmitter<{
     // Publisher object.
     const localPublisher: Publisher =
       typeof publisher === "string" || publisher instanceof HTMLElement
-        ? initPublisher(publisher, properties)
+        ? OT.initPublisher(publisher, properties)
         : publisher;
 
     if (!window.call) {

--- a/src/example.ts
+++ b/src/example.ts
@@ -9,7 +9,7 @@ import "./example.css";
 // } = import.meta.env;
 // OT.setLogLevel(4);
 
-import * as OT from "./";
+import OT from "./";
 import { Publisher } from "./Publisher";
 
 const { VITE_DAILY_MEETING_TOKEN } = import.meta.env;
@@ -18,8 +18,6 @@ const apiKey = "";
 const sessionId = "https://hush.daily.co/demo";
 const token =
   typeof VITE_DAILY_MEETING_TOKEN === "string" ? VITE_DAILY_MEETING_TOKEN : "";
-
-window.OT = OT;
 
 const audioSelector = document.querySelector(
   "#audio-source-select"

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, test, jest } from "@jest/globals";
 import { FakeMediaStreamTrack } from "fake-mediastreamtrack";
-import * as OT from "./index";
+import OT from "./index";
 
 const mockGetUserMedia = jest.fn(async () => {
   return new Promise<MediaStream>((resolve) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import {
   dailyUndefinedError,
 } from "./utils";
 
-export function checkScreenSharingCapability(
+function checkScreenSharingCapability(
   callback: (response: ScreenSharingCapabilityResponse) => void
 ): void {
   return Daily.supportedBrowser().supportsScreenShare
@@ -37,11 +37,11 @@ export function checkScreenSharingCapability(
       });
 }
 
-export function checkSystemRequirements(): number {
+function checkSystemRequirements(): number {
   return Daily.supportedBrowser().supported ? 1 : 0;
 }
 
-export function getActiveAudioOutputDevice(): Promise<AudioOutputDevice> {
+function getActiveAudioOutputDevice(): Promise<AudioOutputDevice> {
   if (!window.call) {
     dailyUndefinedError();
   }
@@ -62,12 +62,12 @@ export function getActiveAudioOutputDevice(): Promise<AudioOutputDevice> {
   });
 }
 
-export function upgradeSystemRequirements() {
+function upgradeSystemRequirements() {
   // Left empty
   console.debug("upgradeSystemRequirements called");
 }
 
-export function getDevices(
+function getDevices(
   callback: (error: OTError | undefined, devices?: OT.Device[]) => void
 ): void {
   window.call =
@@ -101,7 +101,7 @@ export function getDevices(
     });
 }
 
-export function getSupportedCodecs(): Promise<{
+function getSupportedCodecs(): Promise<{
   videoEncoders: ("H264" | "VP8")[];
   videoDecoders: ("H264" | "VP8")[];
 }> {
@@ -113,7 +113,7 @@ export function getSupportedCodecs(): Promise<{
     : Promise.resolve({ videoDecoders: [], videoEncoders: [] });
 }
 
-export function getUserMedia(
+function getUserMedia(
   properties?: GetUserMediaProperties
 ): Promise<MediaStream> {
   if (!properties) {
@@ -174,7 +174,7 @@ export function getUserMedia(
   });
 }
 
-export function hasMediaProcessorSupport(): boolean {
+function hasMediaProcessorSupport(): boolean {
   return Daily.supportedBrowser().supportsVideoProcessing;
 }
 
@@ -183,7 +183,7 @@ export function hasMediaProcessorSupport(): boolean {
 // communications with the cloud. It simply initializes
 // the Session object that you can use to connect (and
 // to perform other operations once connected).
-export function initSession(
+function initSession(
   // Doesn't look like Daily needs this at all, but it's required by the opentok API
   partnerId: string,
   // sessionId in tokbox, renamed this to roomUrl to match the Daily API
@@ -208,7 +208,7 @@ export function initSession(
   return session;
 }
 
-export function initPublisher(
+function initPublisher(
   targetElement?: string | HTMLElement | undefined,
   properties?: OT.PublisherProperties | undefined,
   callback?: ((error?: OTError | undefined) => void) | undefined
@@ -306,7 +306,7 @@ export function initPublisher(
 }
 
 let OTlogLevel = 0;
-export function setLogLevel(logLevel: number): void {
+function setLogLevel(logLevel: number): void {
   OTlogLevel = logLevel;
 }
 
@@ -317,13 +317,13 @@ function runDelayedCallback(callback: (error?: OTError) => void) {
   }, 1000);
 }
 
-export function log(message: string): void {
+function log(message: string): void {
   if (OTlogLevel >= 4) {
     console.debug(message);
   }
 }
 
-export function registerScreenSharingExtension(
+function registerScreenSharingExtension(
   kind: string,
   id: string,
   version: number
@@ -433,3 +433,19 @@ function updateLocalVideoDOM(
     console.error(e);
   });
 }
+
+export default {
+  checkScreenSharingCapability,
+  checkSystemRequirements,
+  getActiveAudioOutputDevice,
+  getDevices,
+  getSupportedCodecs,
+  getUserMedia,
+  hasMediaProcessorSupport,
+  initPublisher,
+  initSession,
+  log,
+  registerScreenSharingExtension,
+  setLogLevel,
+  upgradeSystemRequirements,
+};


### PR DESCRIPTION
Implements [getActiveAudioOutputDevice](https://tokbox.com/developer/sdks/js/reference/OT.html#getActiveAudioOutputDevice) using Daily.

I was having issues with the demo page after merging my last PR. In order to get es modules to have the same behavior as commonjs (require in nodejs), to have the same behavior as a global object on window, you need to export default everything.
If you mix export default with named exports (e.g. export function bar(), export function baz() ) the bundler gets confused. While that’s 100% valid es module code, since there’s no default exports with commonjs or with a global window object, it generates code like this:
```
{
  default: {
    foo: {}
  }
  bar: {}
  baz: {}
}
```
If everything is exported as default the bundler generates code like this:
```
{
  foo: {}
  bar: {}
  baz: {}
}
```
Which is what we were expecting.
This also implements getActiveAudioOutputDevice

# Opentok Output
![image](https://user-images.githubusercontent.com/614910/197732361-cddc08b2-5514-4ceb-98c8-83d2c477a297.png)


# Daily Output
![image](https://user-images.githubusercontent.com/614910/197732111-112c9976-4ca4-4d09-ad66-062e334da5a3.png)
