### PR TITLE
fix: remove engine check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "daily-opentok-client",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "daily-opentok-client",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "license": "MIT",
       "dependencies": {
         "@daily-co/daily-js": "^0.35.1",
@@ -31,9 +31,6 @@
         "typescript": "^4.8.4",
         "vite": "^3.2.5",
         "vite-plugin-mkcert": "^1.10.1"
-      },
-      "engines": {
-        "node": "18.x"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "daily-opentok-client",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "license": "MIT",
   "description": "Daily's OpenTok client-side shim",
   "type": "module",
@@ -59,9 +59,6 @@
     ">0.2%",
     "not dead"
   ],
-  "engines": {
-    "node": "18.x"
-  },
   "repository": {
     "url": "https://github.com/daily-co/opentok"
   }


### PR DESCRIPTION
Remove engine check for for node. This was causing an issue when this package was being consumed by another project with a lower version of node. This is a client library without a `postinstall` step so the node version doesn't matter.