### PR TITLE
Broadcast connection data from token, if available

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@daily-co/daily-js": "^0.35.1",
         "@opentok/client": "^2.23.0",
-        "events": "^3.3.0"
+        "events": "^3.3.0",
+        "jwt-decode": "^3.1.2"
       },
       "devDependencies": {
         "@types/events": "^3.0.0",
@@ -5150,6 +5151,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "node_modules/kleur": {
       "version": "3.0.3",
@@ -11169,6 +11175,11 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
       "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
       "dev": true
+    },
+    "jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "kleur": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   "dependencies": {
     "@daily-co/daily-js": "^0.35.1",
     "@opentok/client": "^2.23.0",
-    "events": "^3.3.0"
+    "events": "^3.3.0",
+    "jwt-decode": "^3.1.2"
   },
   "devDependencies": {
     "@types/events": "^3.0.0",

--- a/src/session/DailyEventHandler.ts
+++ b/src/session/DailyEventHandler.ts
@@ -54,14 +54,14 @@ export class DailyEventHandler {
   }
 
   // onParticipantJoined() handles Daily's "participant-joined" event
-  onParticipantJoined(participant: DailyParticipant) {
+  onParticipantJoined(participant: DailyParticipant, connectionData = "") {
     const { joined_at = new Date(), user_id } = participant;
     const creationTime = joined_at.getTime();
 
     const connection = {
       connectionId: user_id,
       creationTime,
-      data: "",
+      data: connectionData,
     };
 
     const stream = createStream(participant);

--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -15,6 +15,7 @@ import { errNotImplemented } from "../shared/errors";
 import { getOrCreateCallObject } from "../shared/utils";
 import { getConnectionCreatedEvent } from "./OTEvents";
 import { DailyEventObjectParticipant } from "@daily-co/daily-js";
+import jwt_decode from "jwt-decode";
 
 interface SessionCollection {
   length: () => number;
@@ -245,7 +246,7 @@ export class Session extends OTEventEmitter<{
         const connection = {
           connectionId: user_id,
           creationTime,
-          data: "",
+          data: getConnectionData(token),
         };
 
         callback();
@@ -496,4 +497,19 @@ function setupCompletionHandler(
     };
   }
   return { completionHandler, targetElement, properties };
+}
+
+function getConnectionData(token: string): string {
+  if (!token) return "";
+
+  interface Payload {
+    otcd?: string;
+  }
+
+  const payload = jwt_decode(token);
+  const otcd = (payload as Payload).otcd;
+  if (otcd) {
+    return otcd;
+  }
+  return "";
 }

--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -213,7 +213,7 @@ export class Session extends OTEventEmitter<{
   }
   connect(token: string, callback: (error?: OTError) => void): void {
     const call = getOrCreateCallObject();
-
+    const connectionData = getConnectionData(token);
     const eh = this.eventHandler;
     call
       .on("error", (dailyEvent) => {
@@ -246,7 +246,7 @@ export class Session extends OTEventEmitter<{
         const connection = {
           connectionId: user_id,
           creationTime,
-          data: getConnectionData(token),
+          data: connectionData,
         };
 
         callback();
@@ -266,7 +266,7 @@ export class Session extends OTEventEmitter<{
       .on("participant-joined", (dailyEvent) => {
         // Remote
         if (!dailyEvent) return;
-        eh.onParticipantJoined(dailyEvent.participant);
+        eh.onParticipantJoined(dailyEvent.participant, connectionData);
       })
       .on("participant-left", (dailyEvent) => {
         if (!dailyEvent) return;

--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -506,10 +506,12 @@ function getConnectionData(token: string): string {
     otcd?: string;
   }
 
-  const payload = jwt_decode(token);
-  const otcd = (payload as Payload).otcd;
-  if (otcd) {
-    return otcd;
+  let payload: Payload;
+  try {
+    payload = jwt_decode(token);
+  } catch (_) {
+    return "";
   }
-  return "";
+  const otcd = payload.otcd;
+  return otcd ?? "";
 }


### PR DESCRIPTION
This PR gets the connection data claim from the node-shim generated meeting token and ensures it is sent with the `"connectionCreated"` event.

I think there is some wonkiness with the creation events here, as I am getting one extra event than I should, but that seems out of scope of this PR.