### PR TITLE
Fix issue with not all participant video elements being removed

### DIFF
--- a/src/shared/media.ts
+++ b/src/shared/media.ts
@@ -48,7 +48,12 @@ export function removeAllParticipantMedias() {
   const allParticipantDOMs = document.getElementsByClassName(
     participantMediaClassName
   );
-  for (const el of allParticipantDOMs) {
+  // An HTMLCollection is live and updated when underlying
+  // elements change; since we are removing every underlying 
+  // element, the collection will keep dynamically shrinking 
+  // with each iteration until there are no elements left.
+  while (allParticipantDOMs.length > 0) {
+    const el = allParticipantDOMs[0]
     const vid = el as HTMLVideoElement;
     vid.srcObject = null;
     vid.remove();

--- a/src/shared/media.ts
+++ b/src/shared/media.ts
@@ -49,11 +49,11 @@ export function removeAllParticipantMedias() {
     participantMediaClassName
   );
   // An HTMLCollection is live and updated when underlying
-  // elements change; since we are removing every underlying 
-  // element, the collection will keep dynamically shrinking 
+  // elements change; since we are removing every underlying
+  // element, the collection will keep dynamically shrinking
   // with each iteration until there are no elements left.
   while (allParticipantDOMs.length > 0) {
-    const el = allParticipantDOMs[0]
+    const el = allParticipantDOMs[0];
     const vid = el as HTMLVideoElement;
     vid.srcObject = null;
     vid.remove();


### PR DESCRIPTION
The inline comment mostly explains this, but basically an `HTMLCollection` is modified when the underlying elements are. Since we know we will be removing every underlying element here, we can keep removing until the collection is empty.