### PR TITLE
fix: session disconnect bugs

### DIFF
--- a/src/example.ts
+++ b/src/example.ts
@@ -127,6 +127,8 @@ OT.getUserMedia()
 
 // Start publishing when you click the publish button
 publishBtn.addEventListener("click", () => {
+  const videoSource = videoSelector.options[videoSelector.selectedIndex].value;
+  const audioSource = audioSelector.options[audioSelector.selectedIndex].value;
   // Start publishing with the selected devices
   publisher = OT.initPublisher(
     "publisher",
@@ -134,8 +136,8 @@ publishBtn.addEventListener("click", () => {
       insertMode: "append",
       width: "100%",
       height: "100%",
-      audioSource: audioSelector.value,
-      videoSource: videoSelector.value,
+      audioSource,
+      videoSource,
     },
     (err) => {
       if (err) {

--- a/src/example.ts
+++ b/src/example.ts
@@ -324,3 +324,11 @@ session.on("signal", (event) => {
 session.on("signal:test", (event) => {
   console.log("signal:test", event);
 });
+
+session.on("sessionDisconnected", (event) => {
+  console.log("sessionDisconnected", event);
+});
+
+session.on("streamDestroyed", (event) => {
+  console.log("streamDestroyed", event);
+});

--- a/src/publisher/Init.ts
+++ b/src/publisher/Init.ts
@@ -33,6 +33,11 @@ export function initPublisher(
     completionHandler
   );
 
+  const audioSource =
+    properties?.audioSource === null ? undefined : properties?.audioSource;
+  const videoSource =
+    properties?.videoSource === null ? undefined : properties?.videoSource;
+
   // If target element is falsy, invoke completion handler
   // with an error
   if (!targetElement) {
@@ -47,10 +52,15 @@ export function initPublisher(
     case "left-meeting":
     case "loading":
     case "loaded":
-      call.startCamera().catch((err) => {
-        completionHandler(new Error("Failed to start camera"));
-        console.error("startCamera error: ", err);
-      });
+      call
+        .startCamera({
+          audioSource,
+          videoSource,
+        })
+        .catch((err) => {
+          completionHandler(new Error("Failed to start camera"));
+          console.error("startCamera error: ", err);
+        });
       break;
     case "error":
       console.error("error");

--- a/src/publisher/Publisher.ts
+++ b/src/publisher/Publisher.ts
@@ -142,6 +142,20 @@ export class Publisher extends OTEventEmitter<{
         updateMediaDOM(participant, this, rootElementID);
       })
       .on("left-meeting", () => {
+        this.ee.emit("streamDestroyed", {
+          isDefaultPrevented: () => false,
+          preventDefault: () => false,
+          reason: "disconnected",
+          cancelable: false,
+          stream: null,
+        });
+        this.ee.emit("destroyed", {
+          isDefaultPrevented: () => false,
+          preventDefault: () => false,
+          reason: "disconnected",
+          cancelable: false,
+          stream: null,
+        });
         removeAllParticipantMedias();
       })
       .on("participant-updated", onParticipantUpdated);
@@ -165,30 +179,11 @@ export class Publisher extends OTEventEmitter<{
   }
 
   destroy(): void {
-    if (!window.call) {
-      errDailyUndefined();
-    }
-    window.call
-      .leave()
-      .then(() => {
-        this.ee.emit("streamDestroyed", {
-          isDefaultPrevented: () => false,
-          preventDefault: () => false,
-          reason: "disconnected",
-          cancelable: false,
-          stream: null,
-        });
-        this.ee.emit("destroyed", {
-          isDefaultPrevented: () => false,
-          preventDefault: () => false,
-          reason: "disconnected",
-          cancelable: false,
-          stream: null,
-        });
-      })
-      .catch((err) => {
-        console.error(err);
-      });
+    const call = getOrCreateCallObject();
+
+    call.leave().catch((err) => {
+      console.error(err);
+    });
   }
   getImgData(): string | null {
     errNotImplemented(this.getImgData.name);
@@ -222,16 +217,13 @@ export class Publisher extends OTEventEmitter<{
     });
   }
   publishAudio(value: boolean): void {
-    if (!window.call) {
-      errDailyUndefined();
-    }
-    window.call.setLocalAudio(value);
+    const call = getOrCreateCallObject();
+
+    call.setLocalAudio(value);
   }
   publishVideo(value: boolean): this {
-    if (!window.call) {
-      errDailyUndefined();
-    }
-    window.call.setLocalVideo(value);
+    const call = getOrCreateCallObject();
+    call.setLocalVideo(value);
     return this;
   }
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -239,11 +231,9 @@ export class Publisher extends OTEventEmitter<{
     errNotImplemented(this.publishCaptions.name);
   }
   cycleVideo(): Promise<{ deviceId: string }> {
-    if (!window.call) {
-      errDailyUndefined();
-    }
+    const call = getOrCreateCallObject();
 
-    return window.call.cycleCamera().then((device) => {
+    return call.cycleCamera().then((device) => {
       return { deviceId: String(device) };
     });
   }

--- a/src/session/DailyEventHandler.ts
+++ b/src/session/DailyEventHandler.ts
@@ -160,9 +160,20 @@ export class DailyEventHandler {
     );
   }
 
+  // onLeftMeeting() handles Daily's "left-meeting" event
+  onLeftMeeting(target: Session) {
+    this.ee.emit(
+      "sessionDisconnected",
+      getSessionDisconnectedEvent(target, "clientDisconnected")
+    );
+  }
+
   // onNetworkConnection() handles Daily's "network-connection" event
   onNetworkConnection(event: string) {
-    const otEvent = getSessionDisconnectedEvent(this.session);
+    const otEvent = getSessionDisconnectedEvent(
+      this.session,
+      "networkDisconnected"
+    );
 
     switch (event) {
       case "interrupted":

--- a/src/session/DailyEventHandler.ts
+++ b/src/session/DailyEventHandler.ts
@@ -7,6 +7,7 @@ import {
 } from "@daily-co/daily-js";
 import { ExceptionEvent, Stream, Event } from "@opentok/client";
 import { EventEmitter } from "stream";
+import { removeAllParticipantMedias } from "../shared/media";
 import { createStream } from "../shared/ot";
 import {
   getConnectionCreatedEvent,
@@ -166,6 +167,7 @@ export class DailyEventHandler {
       "sessionDisconnected",
       getSessionDisconnectedEvent(target, "clientDisconnected")
     );
+    removeAllParticipantMedias();
   }
 
   // onNetworkConnection() handles Daily's "network-connection" event

--- a/src/session/OTEvents.ts
+++ b/src/session/OTEvents.ts
@@ -106,7 +106,8 @@ export function getConnectionDestroyedEvent(
 }
 
 export function getSessionDisconnectedEvent(
-  target: Session
+  target: Session,
+  reason: "clientDisconnected" | "networkDisconnected"
 ): SessionDisconnectedEvent {
   let defaultPrevented = false;
   const event: Event<"sessionDisconnected", Session> & {
@@ -119,7 +120,7 @@ export function getSessionDisconnectedEvent(
     },
     cancelable: true,
     target: target,
-    reason: "networkDisconnected",
+    reason,
   };
   return event;
 }

--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -264,6 +264,11 @@ export class Session extends OTEventEmitter<{
         if (!dailyEvent) return;
         eh.onParticipantLeft(dailyEvent);
       })
+      .on("left-meeting", (dailyEvent) => {
+        if (!dailyEvent) return;
+
+        eh.onLeftMeeting(this);
+      })
       .on("app-message", (dailyEvent) => {
         if (!dailyEvent) return;
 
@@ -288,8 +293,8 @@ export class Session extends OTEventEmitter<{
       .join({
         url: this.sessionId,
         token,
-        startVideoOff: call.localVideo(),
-        startAudioOff: call.localAudio(),
+        startVideoOff: !call.localVideo(),
+        startAudioOff: !call.localAudio(),
       })
       .catch((e) => {
         if (typeof e === "string") {
@@ -368,37 +373,16 @@ export class Session extends OTEventEmitter<{
   }
 
   disconnect(): void {
-    if (!window.call) {
-      return;
-    }
+    const call = getOrCreateCallObject();
 
     // sessionDisconnected, connectionDestroyed, streamDestroyed are
     // all handled in listeners setup in connect(). In OpenTok's
     // implementation, this function does not throw any errors,
     // so to keep that behavior the same we're logging Daily
     // errors to the console.
-    window.call
-      .leave()
-      .then(() => {
-        let defaultPrevented = false;
-        const tokboxEvent: Event<"sessionDisconnected", Session> & {
-          reason: string;
-        } = {
-          type: "sessionDisconnected",
-          isDefaultPrevented: () => defaultPrevented,
-          preventDefault: () => {
-            defaultPrevented = true;
-          },
-          cancelable: true,
-          target: this,
-          reason: "clientDisconnected",
-        };
-
-        this.ee.emit("sessionDisconnected", tokboxEvent);
-      })
-      .catch((err) => {
-        console.error(err);
-      });
+    call.leave().catch((err) => {
+      console.error(err);
+    });
   }
 
   forceDisconnect(

--- a/src/subscriber/Subscriber.ts
+++ b/src/subscriber/Subscriber.ts
@@ -82,11 +82,16 @@ export class Subscriber extends OTEventEmitter<{
 
     const onParticipantUpdated = (dailyEvent?: DailyEventObjectParticipant) => {
       if (!dailyEvent) return;
-      // Create stream and add it to subscriber
 
-      if (this.id === dailyEvent.participant.session_id) {
+      // Create stream and add it to subscriber if it does not exist
+      if (!this.stream) {
         const stream = createStream(dailyEvent.participant);
         this.stream = stream;
+      }
+
+      const { streamId } = this.stream;
+
+      if (streamId === dailyEvent.participant.session_id) {
         call.off("participant-updated", onParticipantUpdated);
         completionHandler();
       }


### PR DESCRIPTION
We should merge #33 before merging this.

- Fixes issue where there'd be a black video tile left over in the DOM when a user leaves a call.
- Fire events in "left-meeting" instead of using `then` and the "left-meeting" listener. Makes it less confusing to read when they're fired in one place.
- Fix logic issue when joining the meeting with the camera/mic off https://github.com/daily-co/daily-opentok-client/pull/37/files#diff-ef665f6650e3778f480ac2d4d1b310d042ae195faacbd3b4633ee8fe5e52404eR296
- Replace a few calls to window.call with `getOrCreateCallObject()`
