### PR TITLE
fix: camera and mic selections

### DIFF
--- a/src/example.ts
+++ b/src/example.ts
@@ -129,7 +129,6 @@ OT.getUserMedia()
 publishBtn.addEventListener("click", () => {
   const videoSource = videoSelector.options[videoSelector.selectedIndex].value;
   const audioSource = audioSelector.options[audioSelector.selectedIndex].value;
-  console.log(videoSource, audioSource);
   // Start publishing with the selected devices
   publisher = OT.initPublisher(
     "publisher",

--- a/src/example.ts
+++ b/src/example.ts
@@ -127,6 +127,9 @@ OT.getUserMedia()
 
 // Start publishing when you click the publish button
 publishBtn.addEventListener("click", () => {
+  const videoSource = videoSelector.options[videoSelector.selectedIndex].value;
+  const audioSource = audioSelector.options[audioSelector.selectedIndex].value;
+  console.log(videoSource, audioSource);
   // Start publishing with the selected devices
   publisher = OT.initPublisher(
     "publisher",
@@ -134,8 +137,8 @@ publishBtn.addEventListener("click", () => {
       insertMode: "append",
       width: "100%",
       height: "100%",
-      audioSource: audioSelector.value,
-      videoSource: videoSelector.value,
+      audioSource,
+      videoSource,
     },
     (err) => {
       if (err) {

--- a/src/publisher/Init.ts
+++ b/src/publisher/Init.ts
@@ -33,6 +33,11 @@ export function initPublisher(
     completionHandler
   );
 
+  const audioSource =
+    properties?.audioSource === null ? undefined : properties?.audioSource;
+  const videoSource =
+    properties?.videoSource === null ? undefined : properties?.videoSource;
+
   // If target element is falsy, invoke completion handler
   // with an error
   if (!targetElement) {
@@ -47,10 +52,15 @@ export function initPublisher(
     case "left-meeting":
     case "loading":
     case "loaded":
-      call.startCamera().catch((err) => {
-        completionHandler(new Error("Failed to start camera"));
-        console.error("startCamera error: ", err);
-      });
+      call
+        .startCamera({
+          audioSource,
+          videoSource,
+        })
+        .catch((err) => {
+          completionHandler(new Error("Failed to start camera"));
+          console.error("startCamera error: ", err);
+        });
       break;
     case "error":
       console.error("error");

--- a/src/publisher/Publisher.ts
+++ b/src/publisher/Publisher.ts
@@ -233,8 +233,8 @@ export class Publisher extends OTEventEmitter<{
   cycleVideo(): Promise<{ deviceId: string }> {
     const call = getOrCreateCallObject();
 
-    return call.cycleCamera().then((device) => {
-      return { deviceId: String(device) };
+    return call.cycleCamera().then(({ device }) => {
+      return { deviceId: device?.deviceId ?? "" };
     });
   }
   setAudioSource(audioSource: string | MediaStreamTrack): Promise<undefined> {

--- a/src/publisher/Publisher.ts
+++ b/src/publisher/Publisher.ts
@@ -14,7 +14,7 @@ import {
 import { OTEventEmitter } from "../OTEventEmitter";
 import { Session } from "../session/Session";
 import { errDailyUndefined, errNotImplemented } from "../shared/errors";
-import { removeAllParticipantMedias } from "../shared/media";
+import { removeParticipantMedia } from "../shared/media";
 import { createStream } from "../shared/ot";
 import { getOrCreateCallObject } from "../shared/utils";
 import { updateMediaDOM } from "./MediaDOM";
@@ -141,23 +141,6 @@ export class Publisher extends OTEventEmitter<{
         const { participant } = dailyEvent;
         updateMediaDOM(participant, this, rootElementID);
       })
-      .on("left-meeting", () => {
-        this.ee.emit("streamDestroyed", {
-          isDefaultPrevented: () => false,
-          preventDefault: () => false,
-          reason: "disconnected",
-          cancelable: false,
-          stream: null,
-        });
-        this.ee.emit("destroyed", {
-          isDefaultPrevented: () => false,
-          preventDefault: () => false,
-          reason: "disconnected",
-          cancelable: false,
-          stream: null,
-        });
-        removeAllParticipantMedias();
-      })
       .on("participant-updated", onParticipantUpdated);
   }
 
@@ -178,12 +161,38 @@ export class Publisher extends OTEventEmitter<{
     }
   }
 
-  destroy(): void {
+  destroy(): this {
     const call = getOrCreateCallObject();
 
-    call.leave().catch((err) => {
-      console.error(err);
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+
+    const { local } = call.participants();
+
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (!local) {
+      console.warn("No local participant found");
+      return this;
+    }
+
+    removeParticipantMedia(local.session_id);
+
+    this.ee.emit("destroyed", {
+      isDefaultPrevented: () => false,
+      preventDefault: () => false,
+      reason: "disconnected",
+      cancelable: false,
+      stream: null,
     });
+
+    this.ee.emit("streamDestroyed", {
+      isDefaultPrevented: () => false,
+      preventDefault: () => false,
+      reason: "disconnected",
+      cancelable: false,
+      stream: null,
+    });
+
+    return this;
   }
   getImgData(): string | null {
     errNotImplemented(this.getImgData.name);

--- a/src/session/DailyEventHandler.ts
+++ b/src/session/DailyEventHandler.ts
@@ -7,6 +7,7 @@ import {
 } from "@daily-co/daily-js";
 import { ExceptionEvent, Stream, Event } from "@opentok/client";
 import { EventEmitter } from "stream";
+import { removeAllParticipantMedias } from "../shared/media";
 import { createStream } from "../shared/ot";
 import {
   getConnectionCreatedEvent,
@@ -166,6 +167,7 @@ export class DailyEventHandler {
       "sessionDisconnected",
       getSessionDisconnectedEvent(target, "clientDisconnected")
     );
+    removeAllParticipantMedias();
   }
 
   // onNetworkConnection() handles Daily's "network-connection" event

--- a/src/subscriber/Subscriber.ts
+++ b/src/subscriber/Subscriber.ts
@@ -82,11 +82,16 @@ export class Subscriber extends OTEventEmitter<{
 
     const onParticipantUpdated = (dailyEvent?: DailyEventObjectParticipant) => {
       if (!dailyEvent) return;
-      // Create stream and add it to subscriber
 
-      if (this.id === dailyEvent.participant.session_id) {
+      // Create stream and add it to subscriber if it does not exist
+      if (!this.stream) {
         const stream = createStream(dailyEvent.participant);
         this.stream = stream;
+      }
+
+      const { streamId } = this.stream;
+
+      if (streamId === dailyEvent.participant.session_id) {
         call.off("participant-updated", onParticipantUpdated);
         completionHandler();
       }


### PR DESCRIPTION
Fixes an issue where `startCamera` was always using the default camera/microphone instead of the selected ones. Also fixes issue with `cycleCamera` returning `[object Object]` instead of the device id.