### PR TITLE
fix: publisher/subscriber/session destroy logic

### DIFF
--- a/src/publisher/Publisher.ts
+++ b/src/publisher/Publisher.ts
@@ -164,7 +164,17 @@ export class Publisher extends OTEventEmitter<{
   destroy(): this {
     const call = getOrCreateCallObject();
 
-    removeParticipantMedia(call.participants().local.session_id);
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+
+    const { local } = call.participants();
+
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (!local) {
+      console.warn("No local participant found");
+      return this;
+    }
+
+    removeParticipantMedia(local.session_id);
 
     this.ee.emit("destroyed", {
       isDefaultPrevented: () => false,

--- a/src/publisher/Publisher.ts
+++ b/src/publisher/Publisher.ts
@@ -14,10 +14,7 @@ import {
 import { OTEventEmitter } from "../OTEventEmitter";
 import { Session } from "../session/Session";
 import { errDailyUndefined, errNotImplemented } from "../shared/errors";
-import {
-  removeAllParticipantMedias,
-  removeParticipantMedia,
-} from "../shared/media";
+import { removeParticipantMedia } from "../shared/media";
 import { createStream } from "../shared/ot";
 import { getOrCreateCallObject } from "../shared/utils";
 import { updateMediaDOM } from "./MediaDOM";

--- a/src/session/DailyEventHandler.ts
+++ b/src/session/DailyEventHandler.ts
@@ -7,6 +7,7 @@ import {
 } from "@daily-co/daily-js";
 import { ExceptionEvent, Stream, Event } from "@opentok/client";
 import { EventEmitter } from "stream";
+import { removeAllParticipantMedias } from "../shared/media";
 import { createStream } from "../shared/ot";
 import {
   getConnectionCreatedEvent,
@@ -166,6 +167,7 @@ export class DailyEventHandler {
       "sessionDisconnected",
       getSessionDisconnectedEvent(target, "clientDisconnected")
     );
+    removeAllParticipantMedias();
   }
 
   // onNetworkConnection() handles Daily's "network-connection" event

--- a/src/subscriber/Subscriber.ts
+++ b/src/subscriber/Subscriber.ts
@@ -82,16 +82,16 @@ export class Subscriber extends OTEventEmitter<{
 
     const onParticipantUpdated = (dailyEvent?: DailyEventObjectParticipant) => {
       if (!dailyEvent) return;
-      // Create stream and add it to subscriber
 
-      if (this.stream?.streamId === dailyEvent.participant.session_id) {
-        call.off("participant-updated", onParticipantUpdated);
-        completionHandler();
-      }
-
-      if (this.id === dailyEvent.participant.session_id) {
+      // Create stream and add it to subscriber if it does not exist
+      if (!this.stream) {
         const stream = createStream(dailyEvent.participant);
         this.stream = stream;
+      }
+
+      const { streamId } = this.stream;
+
+      if (streamId === dailyEvent.participant.session_id) {
         call.off("participant-updated", onParticipantUpdated);
         completionHandler();
       }

--- a/src/subscriber/Subscriber.ts
+++ b/src/subscriber/Subscriber.ts
@@ -84,6 +84,11 @@ export class Subscriber extends OTEventEmitter<{
       if (!dailyEvent) return;
       // Create stream and add it to subscriber
 
+      if (this.stream?.streamId === dailyEvent.participant.session_id) {
+        call.off("participant-updated", onParticipantUpdated);
+        completionHandler();
+      }
+
       if (this.id === dailyEvent.participant.session_id) {
         const stream = createStream(dailyEvent.participant);
         this.stream = stream;


### PR DESCRIPTION
Fixes a few wrong assumptions with publisher/subscriber/session destroy logic. Mainly how we treated `session.destroy()` and `publisher.destroy()` weren't _quite_ correct. This caused the Network Test code to fail silently as it missed a callback call.