### PR TITLE
feat: attach library to window

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "daily-opentok-client",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "daily-opentok-client",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@daily-co/daily-js": "^0.35.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "daily-opentok-client",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "MIT",
   "description": "Daily's OpenTok client-side shim",
   "type": "module",

--- a/src/example.ts
+++ b/src/example.ts
@@ -20,9 +20,6 @@ const sessionId = "https://hush.daily.co/sfu";
 const token =
   typeof VITE_DAILY_MEETING_TOKEN === "string" ? VITE_DAILY_MEETING_TOKEN : "";
 
-// @ts-expect-error OT isn't a built in method on the window object
-window.OT = OT;
-
 const audioSelector = document.querySelector(
   "#audio-source-select"
 ) as HTMLSelectElement;

--- a/src/index.ts
+++ b/src/index.ts
@@ -200,7 +200,7 @@ function registerScreenSharingExtension(
   return;
 }
 
-export default {
+const OT = {
   checkScreenSharingCapability,
   checkSystemRequirements,
   getActiveAudioOutputDevice,
@@ -222,3 +222,8 @@ export default {
     loggingURL: "https://hlg.tokbox.com/prod", // 'https://hlg.tokbox.com/prod/logging/ClientEvent'
   },
 };
+
+// @ts-expect-error copy Opentok's behavior of attaching OT to the window.
+window.OT = OT;
+
+export default OT;


### PR DESCRIPTION
The Opentok npm library attaches itself to `window` by default. We need to do the same here.